### PR TITLE
fix(expenses): Wire up category field in expense edit dialog

### DIFF
--- a/docs/plans/2026-02-04-fix-expense-category-not-saving-plan.md
+++ b/docs/plans/2026-02-04-fix-expense-category-not-saving-plan.md
@@ -1,0 +1,146 @@
+---
+title: Fix expense category not saving when editing
+type: fix
+date: 2026-02-04
+---
+
+# 🐛 Fix: Expense Category Not Saving When Editing
+
+## Overview
+
+When editing an existing expense via the Edit dialog, changing the category field and saving causes the category to revert to its original value. The category selection is lost because the data flow for category editing was never wired up.
+
+## Problem Statement
+
+The expense form correctly displays a category dropdown, but when editing an existing expense:
+1. The category doesn't populate with the expense's current value
+2. Any category changes are not included in the update mutation
+
+**Root Cause:** Three locations in `expense-dialog.tsx` are missing category handling.
+
+## Proposed Solution
+
+Wire up the category field in the expense edit flow by:
+1. Adding `category` to the expense prop type
+2. Including `category` in the form's default values when editing
+3. Passing `category` to the `updateExpense` mutation
+
+## Technical Approach
+
+### File: `src/components/expenses/expense-dialog.tsx`
+
+**Change 1: Update the expense prop type** (lines 35-43)
+
+```typescript
+// BEFORE
+expense?: {
+  _id: Id<"expenses">
+  datePaid: string
+  provider: string
+  amountCents: number
+  comment?: string
+}
+
+// AFTER
+expense?: {
+  _id: Id<"expenses">
+  datePaid: string
+  provider: string
+  amountCents: number
+  comment?: string
+  category?: string | null  // ADD THIS
+}
+```
+
+**Change 2: Include category in defaultValues** (around line 242-260)
+
+```typescript
+// BEFORE
+const defaultValues = expense
+  ? {
+      datePaid: effectiveOcrData?.date?.value
+        ? new Date(effectiveOcrData.date.value)
+        : new Date(expense.datePaid),
+      provider: effectiveOcrData?.provider?.value ?? expense.provider,
+      amount: effectiveOcrData?.amount?.valueCents
+        ? centsToDollars(effectiveOcrData.amount.valueCents)
+        : centsToDollars(expense.amountCents),
+      comment: expense.comment,
+    }
+  : // ...
+
+// AFTER
+const defaultValues = expense
+  ? {
+      datePaid: effectiveOcrData?.date?.value
+        ? new Date(effectiveOcrData.date.value)
+        : new Date(expense.datePaid),
+      provider: effectiveOcrData?.provider?.value ?? expense.provider,
+      amount: effectiveOcrData?.amount?.valueCents
+        ? centsToDollars(effectiveOcrData.amount.valueCents)
+        : centsToDollars(expense.amountCents),
+      comment: expense.comment,
+      category: expense.category,  // ADD THIS
+    }
+  : // ...
+```
+
+**Change 3: Pass category to updateExpense mutation** (around lines 202-213)
+
+```typescript
+// BEFORE
+await updateExpense({
+  id: expense._id,
+  datePaid: data.datePaid.toISOString().split("T")[0],
+  provider: data.provider,
+  amountCents: dollarsToCents(data.amount),
+  comment: data.comment || undefined,
+})
+
+// AFTER
+await updateExpense({
+  id: expense._id,
+  datePaid: data.datePaid.toISOString().split("T")[0],
+  provider: data.provider,
+  amountCents: dollarsToCents(data.amount),
+  comment: data.comment || undefined,
+  category: data.category ?? null,  // ADD THIS (null clears the category)
+})
+```
+
+## Acceptance Criteria
+
+- [ ] When editing an expense, the category dropdown shows the expense's current category
+- [ ] Changing the category to a different value and saving persists the new category
+- [ ] Changing the category to "No Category" and saving clears the category (sets to null)
+- [ ] Creating a new expense with a category still works correctly
+
+## Context
+
+### Backend Already Supports This
+
+The Convex `update` mutation in `convex/expenses.ts` already handles category correctly:
+
+```typescript
+category: v.optional(v.union(v.string(), v.null())), // Allow null to clear category
+```
+
+- `undefined` = don't change the category
+- `null` = clear the category
+- `string` = set to that category
+
+### Form Component Already Works
+
+The `expense-form.tsx` Select component correctly handles the category:
+- Uses `"__none__"` sentinel for "No Category"
+- Converts to/from `null` on change
+- Works correctly for new expenses
+
+The bug is purely in the dialog's data flow, not in the form or backend.
+
+## References
+
+- `src/components/expenses/expense-dialog.tsx` - Dialog wrapper with edit logic
+- `src/components/expenses/expense-form.tsx` - Form component (no changes needed)
+- `convex/expenses.ts` - Update mutation (no changes needed)
+- `docs/solutions/logic-errors/zod-enum-type-safety.md` - Related pattern for category enums

--- a/docs/solutions/logic-errors/form-edit-dialog-field-synchronization.md
+++ b/docs/solutions/logic-errors/form-edit-dialog-field-synchronization.md
@@ -1,0 +1,203 @@
+---
+title: "Form Fields Missing from Edit Dialog Data Flow"
+category: logic-errors
+tags: [react-hook-form, forms, dialogs, typescript, data-flow, mutations]
+module: form-handling
+symptoms:
+  - "Form field changes don't persist when saving via Edit dialog"
+  - "Field shows in UI but reverts to original value after save"
+  - "Field works in create mode but not edit mode"
+  - "No error messages - field silently ignored"
+date: 2026-02-04
+root_cause: "Field wired in form component but omitted from dialog's type definition, defaultValues, or mutation call"
+---
+
+# Form Fields Missing from Edit Dialog Data Flow
+
+## Problem
+
+When editing an expense, changing the category field and saving caused the value to revert to its original state. The category dropdown appeared and was interactive, but changes were silently discarded.
+
+**Observed behavior:**
+1. Open Edit dialog for an expense with category "Medical Services"
+2. Change category to "Dental Care"
+3. Click Save
+4. Category reverts to "Medical Services"
+
+No errors appeared in console or UI.
+
+## Root Cause
+
+The category field existed in three places but the dialog wrapper only connected two of them:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ ExpenseForm (expense-form.tsx)                                  │
+│   ✓ Renders category Select component                          │
+│   ✓ Zod schema includes category field                         │
+│   ✓ Form submission includes category in data                  │
+└─────────────────────────────────────────────────────────────────┘
+                              ↑
+                    defaultValues (BROKEN)
+                              ↑
+┌─────────────────────────────────────────────────────────────────┐
+│ ExpenseDialog (expense-dialog.tsx)                              │
+│   ✗ Type definition missing category field                     │
+│   ✗ defaultValues didn't include expense.category              │
+│   ✗ updateExpense mutation didn't receive category             │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Three missing pieces in expense-dialog.tsx:**
+
+### 1. Type Definition (line ~35-43)
+
+```typescript
+// BEFORE - category missing from type
+expense?: {
+  _id: Id<"expenses">
+  datePaid: string
+  provider: string
+  amountCents: number
+  comment?: string
+  // category not here!
+}
+
+// AFTER
+expense?: {
+  _id: Id<"expenses">
+  datePaid: string
+  provider: string
+  amountCents: number
+  comment?: string
+  category?: string | null  // Added
+}
+```
+
+### 2. Default Values (line ~242-252)
+
+```typescript
+// BEFORE - category not passed to form
+const defaultValues = expense
+  ? {
+      datePaid: new Date(expense.datePaid),
+      provider: expense.provider,
+      amount: centsToDollars(expense.amountCents),
+      comment: expense.comment,
+      // category not here!
+    }
+
+// AFTER
+const defaultValues = expense
+  ? {
+      datePaid: new Date(expense.datePaid),
+      provider: expense.provider,
+      amount: centsToDollars(expense.amountCents),
+      comment: expense.comment,
+      category: expense.category,  // Added
+    }
+```
+
+### 3. Mutation Call (line ~202-209)
+
+```typescript
+// BEFORE - category not sent to backend
+await updateExpense({
+  id: expense._id,
+  datePaid: data.datePaid.toISOString().split("T")[0],
+  provider: data.provider,
+  amountCents: dollarsToCents(data.amount),
+  comment: data.comment || undefined,
+  // category not here!
+})
+
+// AFTER
+await updateExpense({
+  id: expense._id,
+  datePaid: data.datePaid.toISOString().split("T")[0],
+  provider: data.provider,
+  amountCents: dollarsToCents(data.amount),
+  comment: data.comment || undefined,
+  category: data.category ?? null,  // Added
+})
+```
+
+## Why TypeScript Didn't Catch This
+
+The form's props interface uses `Partial<ExpenseFormData>`:
+
+```typescript
+interface ExpenseFormProps {
+  defaultValues?: Partial<ExpenseFormData>  // Allows missing fields
+  onSubmit: (data: ExpenseFormData) => void
+}
+```
+
+This is intentional (allows optional pre-fill), but means TypeScript won't warn when fields are missing from defaultValues.
+
+## Solution
+
+Wire up all three connection points when adding a field to a form that's wrapped by a dialog:
+
+1. **Type definition** - Add field to the dialog's `expense?` prop type
+2. **Default values** - Include field in `defaultValues` object construction
+3. **Mutation call** - Pass field to the update mutation
+
+## Prevention
+
+### Checklist for Adding Form Fields
+
+When adding a new field to a form wrapped by a dialog:
+
+- [ ] Add field to form component's Zod schema
+- [ ] Add field to form component's JSX (render the input)
+- [ ] Add field to dialog's prop type definition
+- [ ] Add field to dialog's `defaultValues` construction (for edit mode)
+- [ ] Add field to dialog's create mutation call
+- [ ] Add field to dialog's update mutation call
+- [ ] Verify field is in backend mutation args
+
+### Pattern to Avoid
+
+Don't rely on TypeScript catching missing fields when using `Partial<T>`:
+
+```typescript
+// This won't warn about missing fields
+const defaultValues: Partial<FormData> = {
+  name: expense.name,
+  // oops, forgot "category" - no TypeScript error
+}
+```
+
+### Safer Pattern
+
+Create a helper function that TypeScript can check:
+
+```typescript
+function buildExpenseDefaults(expense: Expense): ExpenseFormData {
+  return {
+    datePaid: new Date(expense.datePaid),
+    provider: expense.provider,
+    amount: centsToDollars(expense.amountCents),
+    comment: expense.comment,
+    category: expense.category,  // TypeScript enforces this
+  }
+}
+```
+
+### Testing Verification
+
+When testing edit dialogs:
+
+1. Create a record with all optional fields populated
+2. Open Edit dialog
+3. Verify all fields show correct values (not defaults)
+4. Change each field
+5. Save and verify changes persist
+
+## Related
+
+- `docs/solutions/logic-errors/react-hooks-missing-dependencies.md` - Related React pattern issues
+- `docs/solutions/logic-errors/zod-enum-type-safety.md` - Category enum type safety pattern
+- `src/components/expenses/expense-dialog.tsx` - The fixed component
+- `src/components/expenses/expense-form.tsx` - The form component

--- a/src/components/expenses/expense-dialog.tsx
+++ b/src/components/expenses/expense-dialog.tsx
@@ -38,6 +38,7 @@ interface ExpenseDialogProps {
     provider: string
     amountCents: number
     comment?: string
+    category?: string | null
   }
   ocrData?: OcrExtractedData
 }
@@ -206,6 +207,7 @@ export function ExpenseDialog({
           provider: data.provider,
           amountCents: dollarsToCents(data.amount),
           comment: data.comment || undefined,
+          category: data.category ?? null,
         })
         // Mark OCR as acknowledged when applying data via "Apply Data" button
         if (ocrData) {
@@ -218,6 +220,7 @@ export function ExpenseDialog({
           provider: data.provider,
           amountCents: dollarsToCents(data.amount),
           comment: data.comment || undefined,
+          category: data.category ?? null,
         })
         // Attach uploaded document to the new expense
         if (uploadedDocumentId) {
@@ -249,6 +252,7 @@ export function ExpenseDialog({
           ? centsToDollars(effectiveOcrData.amount.valueCents)
           : centsToDollars(expense.amountCents),
         comment: expense.comment,
+        category: expense.category,
       }
     : effectiveOcrData
       ? {


### PR DESCRIPTION
## Summary

- Fix category field not saving when editing expenses via the Edit dialog
- Category changes were silently discarded because the field wasn't wired through the dialog wrapper

## Root Cause

The `ExpenseDialog` component was missing category handling in three places:
1. Type definition didn't include `category` field
2. `defaultValues` didn't populate category from the expense
3. `updateExpense` mutation call didn't pass category

## Changes

- Added `category` to the expense prop type definition
- Added `category` to defaultValues when editing
- Added `category` to both `updateExpense` and `createExpense` mutation calls
- Documented this pattern in `docs/solutions/logic-errors/` to prevent similar bugs

## Test plan

- [ ] Edit an expense that has a category set
- [ ] Verify the category dropdown shows the correct current value
- [ ] Change the category and save
- [ ] Verify the new category persists
- [ ] Change category to "No Category" and save
- [ ] Verify category is cleared

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where expense category changes were not persisting when editing expenses. The category field is now properly synchronized throughout the edit workflow and saves correctly to the backend.

* **Documentation**
  * Added comprehensive documentation detailing the category field synchronization fix and prevention guidelines for similar issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->