### PR TITLE
docs: Add compound learnings for currency and null/undefined patterns

### DIFF
--- a/docs/solutions/logic-errors/currency-format-mismatch.md
+++ b/docs/solutions/logic-errors/currency-format-mismatch.md
@@ -1,0 +1,118 @@
+---
+title: "Currency Display Using Wrong Format Function"
+category: logic-errors
+tags: [currency, formatting, cents, dollars, display]
+module: currency-handling
+symptoms:
+  - "Dollar amounts display as 100x their actual value"
+  - "Amount shows $2550.00 instead of $25.50"
+  - "Currency formatting looks correct but values are wrong"
+root_cause: "formatCurrency() called with dollars when it expects cents"
+date: 2026-02-05
+---
+
+# Currency Display Using Wrong Format Function
+
+## Problem
+
+When displaying OCR-extracted amounts in diff indicators, values appeared as 100x their actual value. An expense of $25.50 displayed as "$2550.00" in the OCR comparison tooltip.
+
+**Observed behavior:**
+1. OCR extracts amount as `25.50` (dollars, decimal format)
+2. Diff indicator displays "$2550.00"
+3. No errors in console
+
+## Root Cause
+
+The codebase has two currency display functions with different expectations:
+
+```typescript
+// formatCurrency expects CENTS (integer)
+formatCurrency(2550)  // → "$25.50"
+
+// formatDollars expects DOLLARS (decimal)
+formatDollars(25.50)  // → "$25.50"
+```
+
+The bug occurred because OCR values are already in dollars, but `formatCurrency()` was used:
+
+```typescript
+// ❌ WRONG - formatCurrency expects cents, not dollars
+const ocrAmount = 25.50  // Already in dollars from OCR
+formatCurrency(ocrAmount)  // Treats 25.50 as cents → "$2550.00"
+
+// ✓ CORRECT
+formatDollars(ocrAmount)  // → "$25.50"
+```
+
+## Why This Happens
+
+Values exist in two formats throughout the app:
+
+| Source | Format | Example |
+|--------|--------|---------|
+| Database | Integer cents | `2550` |
+| Form inputs | Decimal dollars | `25.50` |
+| OCR extraction | Decimal dollars | `25.50` |
+| API responses | Usually cents | `2550` |
+
+The confusion arises at boundaries where formats change:
+- `centsToDollars()` converts database → form
+- `dollarsToCents()` converts form → database
+- Display functions must match the format they receive
+
+## Solution
+
+Match the display function to the value format:
+
+```typescript
+// Database value (cents) → formatCurrency
+formatCurrency(expense.amountCents)  // ✓
+
+// Form/OCR value (dollars) → formatDollars
+formatDollars(ocrValues.amount)  // ✓
+
+// Double conversion (common mistake)
+formatCurrency(centsToDollars(expense.amountCents))  // ❌ Wrong!
+formatDollars(centsToDollars(expense.amountCents))   // ✓ Correct
+```
+
+## Prevention
+
+### Check the variable's origin
+
+Before formatting, trace where the value comes from:
+
+1. **From database (convex query)?** → It's cents → use `formatCurrency()`
+2. **From form state?** → It's dollars → use `formatDollars()`
+3. **From OCR/external source?** → Usually dollars → use `formatDollars()`
+4. **After `centsToDollars()` conversion?** → It's dollars → use `formatDollars()`
+
+### Naming convention
+
+Use consistent suffixes to make format obvious:
+
+```typescript
+const amountCents = expense.amountCents        // Cents (integer)
+const amountDollars = centsToDollars(amountCents)  // Dollars (decimal)
+
+formatCurrency(amountCents)   // ✓ Clear
+formatDollars(amountDollars)  // ✓ Clear
+```
+
+### Type safety (future improvement)
+
+Consider branded types to catch mismatches at compile time:
+
+```typescript
+type Cents = number & { __brand: 'cents' }
+type Dollars = number & { __brand: 'dollars' }
+
+function formatCurrency(cents: Cents): string
+function formatDollars(dollars: Dollars): string
+```
+
+## Related
+
+- `src/lib/currency.ts` - Currency utility functions
+- `docs/solutions/logic-errors/form-edit-dialog-field-synchronization.md` - Form data flow issues

--- a/docs/solutions/logic-errors/null-undefined-backend-validators.md
+++ b/docs/solutions/logic-errors/null-undefined-backend-validators.md
@@ -1,0 +1,156 @@
+---
+title: "null vs undefined Mismatch in Backend Validators"
+category: logic-errors
+tags: [convex, validators, null, undefined, typescript, forms]
+module: backend-validation
+symptoms:
+  - "ArgumentValidationError: Value does not match validator"
+  - "Path: .fieldName, Value: null, Validator: v.string()"
+  - "Field works in create but fails in update (or vice versa)"
+  - "Clearing a field causes save to fail"
+root_cause: "Frontend sends null but backend validator only accepts undefined"
+date: 2026-02-05
+---
+
+# null vs undefined Mismatch in Backend Validators
+
+## Problem
+
+When updating an expense and clearing the category field, the save operation failed with a validation error. The category dropdown allowed clearing the selection, but the backend rejected the `null` value.
+
+**Observed behavior:**
+1. Open Edit dialog for expense with category "Medical Services"
+2. Clear the category dropdown (select empty option)
+3. Click Save
+4. Error: `ArgumentValidationError: Value does not match validator`
+5. Error details: `Path: .category, Value: null, Validator: v.string()`
+
+## Root Cause
+
+Convex's `v.optional()` validator only accepts `undefined`, not `null`:
+
+```typescript
+// Convex schema
+category: v.optional(v.string())  // Accepts: undefined | string
+                                  // Rejects: null ❌
+```
+
+But the frontend form (using Zod with `.nullish()`) sends `null` when a field is cleared:
+
+```typescript
+// Frontend sends
+{ category: null }  // Cleared dropdown sends null
+
+// Backend expects
+{ category: undefined }  // or just omit the field
+```
+
+## Why This Happens
+
+JavaScript and TypeScript treat `null` and `undefined` differently:
+
+| Scenario | Form Value | What Frontend Sends |
+|----------|------------|---------------------|
+| Field never touched | `undefined` | Field omitted |
+| Field cleared by user | `null` | `category: null` |
+| Field set to value | `"Dental"` | `category: "Dental"` |
+
+Zod's `.nullish()` is designed to handle both:
+```typescript
+z.string().nullish()  // Accepts: undefined | null | string
+```
+
+But Convex's `v.optional()` is stricter:
+```typescript
+v.optional(v.string())  // Accepts: undefined | string (NOT null)
+```
+
+## Solution
+
+### Option 1: Update backend to accept null (recommended for clearable fields)
+
+```typescript
+// convex/schema.ts
+export default defineSchema({
+  expenses: defineTable({
+    // ... other fields
+    category: v.optional(v.union(v.string(), v.null())),
+  }),
+})
+
+// convex/expenses.ts mutation args
+args: {
+  category: v.optional(v.union(v.string(), v.null())),
+}
+```
+
+### Option 2: Convert null to undefined on frontend
+
+```typescript
+// In dialog's mutation call
+await updateExpense({
+  // ...
+  category: data.category || undefined,  // null → undefined
+})
+```
+
+**Caveat:** This works but loses the distinction between "field was cleared" and "field was never touched."
+
+### Option 3: Transform in Zod schema
+
+```typescript
+// In validation schema
+category: z.string().nullish().transform(val => val ?? undefined)
+```
+
+## Prevention
+
+### Match frontend and backend nullable semantics
+
+For clearable optional fields:
+```typescript
+// Frontend (Zod)
+category: z.string().nullish()
+
+// Backend (Convex)
+category: v.optional(v.union(v.string(), v.null()))
+
+// Frontend submission
+category: data.category ?? null  // undefined → null for consistency
+```
+
+For non-clearable optional fields:
+```typescript
+// Frontend (Zod)
+comment: z.string().optional()
+
+// Backend (Convex)
+comment: v.optional(v.string())
+
+// Frontend submission
+comment: data.comment || undefined  // empty string → undefined
+```
+
+### Validation checklist
+
+When adding optional fields:
+
+- [ ] Decide if field is clearable (can user explicitly clear it?)
+- [ ] If clearable: backend needs `v.union(v.string(), v.null())`
+- [ ] If not clearable: use `v.optional(v.string())`
+- [ ] Frontend submission matches backend expectation
+
+### Quick reference
+
+| Field Type | Zod | Convex | Submission Transform |
+|------------|-----|--------|---------------------|
+| Required | `z.string()` | `v.string()` | None |
+| Optional, not clearable | `z.string().optional()` | `v.optional(v.string())` | `\|\| undefined` |
+| Optional, clearable | `z.string().nullish()` | `v.optional(v.union(v.string(), v.null()))` | `?? null` |
+
+## Related
+
+- `convex/schema.ts` - Database schema definitions
+- `convex/expenses.ts` - Expense mutations with validators
+- `src/lib/validations/expense.ts` - Zod validation schemas
+- `docs/solutions/logic-errors/form-edit-dialog-field-synchronization.md` - Form data flow


### PR DESCRIPTION
## Summary
- Add currency handling guide to CLAUDE.md (two-format rule, display functions, common mistakes)
- Add form field wiring checklist to CLAUDE.md for dialog-wrapped forms
- Add null vs undefined patterns for Convex backend validators to CLAUDE.md
- Document currency format mismatch solution in `docs/solutions/logic-errors/`
- Document null/undefined backend validator solution in `docs/solutions/logic-errors/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded development guidelines with structured guidance on currency handling (database cents vs form dollars), form field integration patterns, and nullability semantics for optional fields
  * Added new troubleshooting guides addressing currency format mismatches and null vs undefined validation failures in backend validators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->