### PR TITLE
fix: Don't show OCR banner after adding new expense (#16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,13 +97,16 @@ See [`docs/testing-conventions.md`](docs/testing-conventions.md) for full testin
 - Database migrations that drop or truncate tables
 - `git reset --hard`, `git clean -f`, or other commands that discard changes
 - Deleting files or directories
+- **Never `taskkill` across all instances of an executable** (e.g., `taskkill //F //IM chrome.exe`). This kills the user's browser windows, not just automation processes. If a browser automation socket is stale, remove the socket file instead.
+
+**Browser automation must always use `--headed` mode** (`agent-browser --headed`). Headless sessions cannot authenticate via OAuth. Save screenshots to a temp directory (e.g., `/tmp/`), never to the project directory.
 
 When implementing destructive functionality: write the code, push/deploy it, then **stop and wait** for the user to decide when to run it.
 
 ## User Preferences
 
 - **Ask for information instead of using placeholders.** When you need specific information (URLs, credentials, names, etc.), ask the user directly rather than inserting placeholders or leaving manual steps.
-- **Always use git worktrees when executing work plans.** Create an isolated worktree before implementing changes to keep the main branch clean.
+- **Always use git worktrees when executing work plans.** Create an isolated worktree before implementing changes to keep the main branch clean. Always use the `/git-worktree` skill when creating, switching, or removing worktrees.
 
 ## Plans
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ When implementing destructive functionality: write the code, push/deploy it, the
 ## User Preferences
 
 - **Ask for information instead of using placeholders.** When you need specific information (URLs, credentials, names, etc.), ask the user directly rather than inserting placeholders or leaving manual steps.
+- **Always use git worktrees when executing work plans.** Create an isolated worktree before implementing changes to keep the main branch clean.
 
 ## Plans
 

--- a/convex/ocr.test.ts
+++ b/convex/ocr.test.ts
@@ -1,0 +1,125 @@
+import { convexTest } from "convex-test"
+import { expect, test, describe } from "vitest"
+import { api, internal } from "./_generated/api"
+import schema from "./schema"
+import { modules } from "./test.setup"
+
+async function createAuthenticatedContext() {
+  const t = convexTest(schema, modules)
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert("users", {
+      name: "Test User",
+      email: "test@example.com",
+      isOwner: true,
+    })
+  })
+  const authed = t.withIdentity({ subject: userId as unknown as string })
+  return { t, authed, userId }
+}
+
+/** Create a document with a valid storage ID in the test environment. */
+async function createTestDocument(
+  t: ReturnType<typeof convexTest>,
+  userId: string
+) {
+  return await t.run(async (ctx) => {
+    const blob = new Blob(["test file content"], { type: "image/jpeg" })
+    const storageId = await ctx.storage.store(blob)
+    return await ctx.db.insert("documents", {
+      userId,
+      originalFilename: "receipt.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: blob.size,
+      storageId,
+      ocrStatus: "processing",
+    })
+  })
+}
+
+describe("updateOcrResults", () => {
+  test("resets ocrAcknowledged on owning expense when new OCR data completes", async () => {
+    const { t, authed, userId } = await createAuthenticatedContext()
+
+    const documentId = await createTestDocument(t, userId as unknown as string)
+
+    // Create an expense and attach the document
+    const expenseId = await authed.mutation(api.expenses.create, {
+      datePaid: "2026-01-15",
+      provider: "Test Provider",
+      amountCents: 5000,
+    })
+    await authed.mutation(api.documents.addToExpense, {
+      expenseId,
+      documentId,
+    })
+    await authed.mutation(api.expenses.acknowledgeOcr, { id: expenseId })
+
+    // Verify acknowledged
+    const beforeExpense = await t.run(async (ctx) => ctx.db.get(expenseId))
+    expect(beforeExpense?.ocrAcknowledged).toBe(true)
+
+    // Simulate OCR completion with extracted data
+    await t.run(async (ctx) => {
+      await ctx.runMutation(internal.ocr.updateOcrResults, {
+        documentId,
+        ocrExtractedData: {
+          amount: { valueCents: 2500, confidence: 0.95 },
+          provider: { value: "Pharmacy", confidence: 0.9 },
+        },
+      })
+    })
+
+    // ocrAcknowledged should be reset to false
+    const afterExpense = await t.run(async (ctx) => ctx.db.get(expenseId))
+    expect(afterExpense?.ocrAcknowledged).toBe(false)
+  })
+
+  test("does NOT reset ocrAcknowledged when OCR data has no extractable fields", async () => {
+    const { t, authed, userId } = await createAuthenticatedContext()
+
+    const documentId = await createTestDocument(t, userId as unknown as string)
+
+    const expenseId = await authed.mutation(api.expenses.create, {
+      datePaid: "2026-01-15",
+      provider: "Test Provider",
+      amountCents: 5000,
+    })
+    await authed.mutation(api.documents.addToExpense, {
+      expenseId,
+      documentId,
+    })
+    await authed.mutation(api.expenses.acknowledgeOcr, { id: expenseId })
+
+    // OCR completes with empty data
+    await t.run(async (ctx) => {
+      await ctx.runMutation(internal.ocr.updateOcrResults, {
+        documentId,
+        ocrExtractedData: {},
+      })
+    })
+
+    // ocrAcknowledged should still be true
+    const afterExpense = await t.run(async (ctx) => ctx.db.get(expenseId))
+    expect(afterExpense?.ocrAcknowledged).toBe(true)
+  })
+
+  test("does NOT reset ocrAcknowledged when document is not attached to any expense", async () => {
+    const { t, userId } = await createAuthenticatedContext()
+
+    const documentId = await createTestDocument(t, userId as unknown as string)
+
+    // OCR completes — no expense to reset
+    await t.run(async (ctx) => {
+      await ctx.runMutation(internal.ocr.updateOcrResults, {
+        documentId,
+        ocrExtractedData: {
+          amount: { valueCents: 1000, confidence: 0.8 },
+        },
+      })
+    })
+
+    // Should not throw — just a no-op for the reset logic
+    const doc = await t.run(async (ctx) => ctx.db.get(documentId))
+    expect(doc?.ocrStatus).toBe("completed")
+  })
+})

--- a/convex/ocr.ts
+++ b/convex/ocr.ts
@@ -52,6 +52,24 @@ export const updateOcrResults = internalMutation({
       ocrStatus: "completed",
       ocrExtractedData,
     })
+
+    // Reset ocrAcknowledged on owning expense when new OCR data has extractable fields.
+    // Linear scan over user's expenses is acceptable at personal-tracker scale (~<1000 expenses).
+    const { amount, date, provider } = ocrExtractedData
+    if (amount || date || provider) {
+      const doc = await ctx.db.get(documentId)
+      if (doc?.userId) {
+        const expenses = await ctx.db
+          .query("expenses")
+          .withIndex("by_user", (q) => q.eq("userId", doc.userId))
+          .collect()
+        for (const expense of expenses) {
+          if (expense.documentIds.includes(documentId) && expense.ocrAcknowledged) {
+            await ctx.db.patch(expense._id, { ocrAcknowledged: false })
+          }
+        }
+      }
+    }
   },
 })
 

--- a/src/components/expenses/expense-dialog.tsx
+++ b/src/components/expenses/expense-dialog.tsx
@@ -267,7 +267,13 @@ export function ExpenseDialog({
         if (uploadedDocumentId) {
           await addToExpense({ expenseId, documentId: uploadedDocumentId })
         }
+        // Mark as successful BEFORE acknowledgeOcr so cleanup doesn't delete
+        // the already-attached document if acknowledgeOcr fails
         submittedSuccessfully.current = true
+        // Mark OCR as acknowledged if data was pre-filled during creation
+        if (localOcrData) {
+          await acknowledgeOcr({ id: expenseId })
+        }
         toast.success("Expense created successfully")
       }
       onOpenChange(false)

--- a/src/components/expenses/expense-dialog.tsx
+++ b/src/components/expenses/expense-dialog.tsx
@@ -272,7 +272,11 @@ export function ExpenseDialog({
         submittedSuccessfully.current = true
         // Mark OCR as acknowledged if data was pre-filled during creation
         if (localOcrData) {
-          await acknowledgeOcr({ id: expenseId })
+          try {
+            await acknowledgeOcr({ id: expenseId })
+          } catch (err) {
+            console.warn("Non-fatal: failed to acknowledge OCR for expense", expenseId, err)
+          }
         }
         toast.success("Expense created successfully")
       }


### PR DESCRIPTION
## Summary

- Acknowledge OCR data on new expense creation when form was pre-filled from OCR
- Reset `ocrAcknowledged` when new OCR data completes for a document on an already-acknowledged expense
- Add safety rules to CLAUDE.md (browser automation, worktree usage)

## Changes

**Backend (`convex/ocr.ts`):** After `updateOcrResults` stores extracted data on a document, check if the document is attached to an expense with `ocrAcknowledged: true`. If the new OCR data has extractable fields, reset the flag to `false` so the banner re-appears.

**Frontend (`src/components/expenses/expense-dialog.tsx`):** In the create path of `handleSubmit`, call `acknowledgeOcr()` after the expense is created and the document is attached, when `localOcrData` is truthy (OCR was used to pre-fill the form).

## Test plan

- [x] 3 new backend tests in `convex/ocr.test.ts` covering reset behavior
- [x] All 179 existing tests pass
- [x] TypeScript type check passes
- [x] Lint passes (0 errors)
- [x] Production build succeeds
- [x] Browser validation: no spurious sparkle icons or OCR banners on existing expenses

Closes #16

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCR now automatically resets acknowledgment on affected expenses when meaningful fields (amount/date/provider) are extracted.

* **Bug Fixes**
  * Ensured expense submissions are marked successful before running OCR acknowledgment to prevent document cleanup issues.
  * OCR acknowledgement attempts on create are non-fatal (warn on failure).

* **Documentation**
  * Added safety rules and workflow guidelines.

* **Tests**
  * Added tests covering OCR result handling and acknowledgement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->